### PR TITLE
gatemate pll module revision and lvds support

### DIFF
--- a/clocks/gatemate_25MHz_125MHz_pll.v
+++ b/clocks/gatemate_25MHz_125MHz_pll.v
@@ -5,63 +5,67 @@
  * SPDX-License-Identifier: MIT
  */
 
+module divide_5 (
+	input  clk_i,
+	output clk_o
+);
+	wire d2, d1, d0, q2bar, q1bar, q0bar;
+	reg  q2 = 0, q1 = 0, q0 = 0, q2temp = 0;
+
+	assign q2bar = ~q2;
+	assign q1bar = ~q1;
+	assign q0bar = ~q0;
+
+	assign d0 = (q2bar & q0bar);
+	assign d1 = (q1 & q0bar) | (q1bar & q0);
+	assign d2 = (q1 & q0);
+
+	always @(posedge clk_i) begin
+		q0 <= d0;
+		q1 <= d1;
+		q2 <= d2;
+	end
+
+	always @(negedge clk_i) begin
+		q2temp <= q1;
+	end
+
+	assign clk_o = q1 | q2temp;
+endmodule
+
 module pll (
 	input  wire clock_in,
-	input  wire rst_in,
-	output wire clock0_out,
-	output reg  clock0_lock,
-	output wire clock1_out,
-	output reg  clock1_lock
+	output wire clock_out,
+	output wire clock_5x_out,
+	output reg  lock_out
 );
 
-wire clk270, clk180, clk90, clk0, usr_ref_out;
+initial lock_out = 1'b0;
+
 wire usr_pll_lock_stdy, usr_pll_lock;
 
-wire pll_clk_nobuf;
 CC_PLL #(
-    .REF_CLK("10.0"),    // reference input in MHz
-    .OUT_CLK("25.0"),    // pll output frequency in MHz
-    //.PERF_MD("ECONOMY"), // LOWPOWER, ECONOMY, SPEED // uncomment to let p_r autodetect PERF_MD based on delay file
-    .LOW_JITTER(1),      // 0: disable, 1: enable low jitter mode
-    .CI_FILTER_CONST(2), // optional CI filter constant
-    .CP_FILTER_CONST(4)  // optional CP filter constant
-) pll25 (
-    .CLK_REF(clock_in), .CLK_FEEDBACK(1'b0), .USR_CLK_REF(1'b0),
-    .USR_LOCKED_STDY_RST(1'b0), .USR_PLL_LOCKED_STDY(usr_pll_lock_stdy), .USR_PLL_LOCKED(usr_pll_lock),
-	.CLK270(clk270), .CLK180(clk180), .CLK90(clk90), .CLK0(clock0_out), .CLK_REF_OUT(usr_ref_out)
-);
-//CC_BUFG pll_bufg (.I(pll_clk_nobuf), .O(clock0_out)); // yosys automatically inserts bufg
-
-// reset is synced the clock
-reg locked_s1;
-always @(posedge clock0_out) begin
-	//locked_s1 <= usr_pll_lock;//_stdy; // requires -lockreq parameter in latest p_r
-	locked_s1 <= ~rst_in;
-	clock0_lock <= locked_s1;
-end
-
-wire usr_pll125_lock_stdy, usr_pll125_lock;
-wire pll125_clk_nobuf;
-CC_PLL #(
-    .REF_CLK("10.0"),    // reference input in MHz
-    .OUT_CLK("125.0"),   // pll output frequency in MHz
-    //.PERF_MD("ECONOMY"), // LOWPOWER, ECONOMY, SPEED // uncomment to let p_r autodetect PERF_MD based on delay file
-    .LOW_JITTER(1),      // 0: disable, 1: enable low jitter mode
-    .CI_FILTER_CONST(2), // optional CI filter constant
-    .CP_FILTER_CONST(4)  // optional CP filter constant
+	.REF_CLK("10.0"),    // reference input in MHz
+	.OUT_CLK("125.0"),   // pll output frequency in MHz
+	.LOW_JITTER(1),      // 0: disable, 1: enable low jitter mode
+	.CI_FILTER_CONST(2), // optional CI filter constant
+	.CP_FILTER_CONST(4)  // optional CP filter constant
 ) pll125 (
-    .CLK_REF(clock_in), .CLK_FEEDBACK(1'b0), .USR_CLK_REF(),
-    .USR_LOCKED_STDY_RST(1'b0), .USR_PLL_LOCKED_STDY(usr_pll125_lock_stdy), .USR_PLL_LOCKED(usr_pll125_lock),
-	.CLK270(), .CLK180(), .CLK90(), .CLK0(clock1_out), .CLK_REF_OUT()
+	.CLK_REF(clock_in), .CLK_FEEDBACK(1'b0), .USR_CLK_REF(1'b0),
+	.USR_LOCKED_STDY_RST(1'b0), .USR_PLL_LOCKED_STDY(usr_pll_lock_stdy), .USR_PLL_LOCKED(usr_pll_lock),
+	.CLK270(), .CLK180(), .CLK90(), .CLK0(clock_5x_out), .CLK_REF_OUT()
 );
-//CC_BUFG pll125_bufg (.I(pll125_clk_nobuf), .O(clock1_out)); // yosys automatically inserts bufg
 
 // reset is synced the clock
-reg locked125_s1;
-always @(posedge clock1_out) begin
-	//locked125_s1 <= usr_pll125_lock;//_stdy; // requires -lockreq parameter in latest p_r
-	locked125_s1 <= ~rst_in;
-	clock1_lock <= locked125_s1;
+reg locked_s1 = 1'b0;
+always @(posedge clock_5x_out) begin
+	locked_s1 <= usr_pll_lock;
+	lock_out <= locked_s1;
 end
+
+divide_5 div_inst (
+	.clk_i(clock_5x_out),
+	.clk_o(clock_out)
+);
 
 endmodule

--- a/graphics/dvi_core.v
+++ b/graphics/dvi_core.v
@@ -18,10 +18,8 @@ module dvi_core (
 	input  wire [7:0] pix_g,
 	input  wire [7:0] pix_b,
 	// output signals
-	output wire       TMDS_clk_p,
-	output wire       TMDS_clk_n,
-	output wire [2:0] TMDS_data_p,
-	output wire [2:0] TMDS_data_n
+	output wire       TMDS_clk,
+	output wire [2:0] TMDS_data
 );
 	wire [9:0] red2_s, green2_s, blue2_s;
 
@@ -37,9 +35,9 @@ module dvi_core (
 
 	/* clock serializer */
 	serializer serClk(.ref_clk_i(clk_pix), .fast_clk_i(clk_dvi), .rst(rst),
-		.dat_i(10'b0000011111), .dat_o_p(TMDS_clk_p), .dat_o_n(TMDS_clk_n));
+		.dat_i(10'b0000011111), .dat_o(TMDS_clk));
 
 	/* data serializer */
 	serializer serDat[2:0](.ref_clk_i(clk_pix), .fast_clk_i(clk_dvi), .rst(rst),
-		.dat_i({red2_s, green2_s, blue2_s}), .dat_o_p(TMDS_data_p), .dat_o_n(TMDS_data_n));
+		.dat_i({red2_s, green2_s, blue2_s}), .dat_o(TMDS_data));
 endmodule

--- a/ios/serializer_gatemate_10_to_1_generic_ddr.v
+++ b/ios/serializer_gatemate_10_to_1_generic_ddr.v
@@ -10,8 +10,7 @@ module serializer (
 	input  wire       fast_clk_i, // must be ref_clk frequency x (n / 2)
 	input  wire       rst,
 	input  wire [9:0] dat_i,
-	output wire       dat_o_p,
-	output wire       dat_o_n
+	output wire       dat_o
 );
 
 	/* detect ref_clk_i edge */
@@ -35,13 +34,11 @@ module serializer (
 			dat_pos <= {2'b0, dat_pos[9:2]};
 	end
 
-	CC_ODDR dat_ddr_pos (.CLK(~fast_clk_i), .DDR(fast_clk_i),
-		.D0(dat_pos[0]), .D1(dat_pos[1]),
-		.Q(dat_o_p)
-	);
-	CC_ODDR dat_ddr_neg (.CLK(~fast_clk_i), .DDR(fast_clk_i),
-		.D0(~dat_pos[0]), .D1(~dat_pos[1]),
-		.Q(dat_o_n)
+	CC_ODDR #(
+		.CLK_INV(1'b0)
+	) ddr_inst (.CLK(fast_clk_i), .DDR(fast_clk_i),
+		.D0(~dat_pos[1]), .D1(~dat_pos[0]),
+		.Q(dat_o)
 	);
 
 endmodule


### PR DESCRIPTION
This PR addresses some issues with the PLL and simplifies the internal processing of TMDS signals.

- 962d12082fc7db391817f35c7396c0df4fb07826 Reduces the module to a single PLL with a separate divider by 5 for generating the 125 MHz and 25 MHz signals. Synthesis will automatically infer two `CC_BUFG` instances for both clocks. Is it ok to use more meaningful port names?
- dc54050620ef35fc9adb6eac35097cb10947fbdf Handles the TMDS signals single-ended to reduce internal overhead.